### PR TITLE
Passing assignmentID to Qualtrics

### DIFF
--- a/TurkGate/gateway.php
+++ b/TurkGate/gateway.php
@@ -84,7 +84,7 @@ if ($isPreview) {
 			$surveyURL .= '?';
 		}
 		
-		$surveyURL .= "workerId=$workerId";
+		$surveyURL .= "workerID=$workerId&assignmentID=$assignId";
 	}
 		
 	// This is the form for submitting the completion codes and comments for an


### PR DESCRIPTION
The R Package "MTurkR" offers a nice way to automate granting bonuses, but requires assignmentID as well as workerID as input. This modification adds "assignmentID" to surveyURL (if SEND_ID_TO_SURVEY is set to true).

I also renamed "workerId" to "workerID" in the surveyURL, which seems more intuitive.
