### PR TITLE
Save survey URL without worker ID on the end.

### DIFF
--- a/TurkGate/admin/testWebHIT.php
+++ b/TurkGate/admin/testWebHIT.php
@@ -21,8 +21,8 @@
 
 	$template = file_get_contents('../resources/WebHIT/webTemplate.html');
 	
-	$searchValues = array('[[[Survey URL]]]', '[[[Group Name]]]', '[[[TurkGate URL]]]');
-	$replacements = array($_GET['survey'], $_GET['group'], constant('BASE_URL'));
+	$searchValues = array('[[[Survey URL]]]', '[[[Group Name]]]', '[[[TurkGate URL]]]', '[[[Pass ID]]]');
+	$replacements = array($_GET['survey'], $_GET['group'], constant('BASE_URL'), "true");
 	
 	echo str_replace($searchValues, $replacements, $template);
 ?>

--- a/TurkGate/gateway.php
+++ b/TurkGate/gateway.php
@@ -88,7 +88,7 @@ if ($isPreview) {
     $surveyURL .= "assignmentID=$assignId";
 
     // Pass along workerId if necessary
-    if ($_GET['passId'] == true) {
+    if ($_GET['passId'] == "true") {
         $surveyURL .= "&workerID=$workerId";
     }
 		

--- a/TurkGate/gateway.php
+++ b/TurkGate/gateway.php
@@ -72,6 +72,9 @@ if ($isPreview) {
 	    $surveyURL = 'admin/testDestination.php';
 	}
 
+    // Save copy of URL for database
+    $surveyURLSave = $surveyURL;
+
     // first character depends on whether there are other variables
     $varsBegin = strrchr($surveyURL, '?');
     if ($varsBegin) {
@@ -83,6 +86,11 @@ if ($isPreview) {
     }
     // Pass assignmentId to survey
     $surveyURL .= "assignmentID=$assignId";
+
+    // Pass along workerId if necessary
+    if ($_GET['passId'] == true) {
+        $surveyURL .= "&workerID=$workerId";
+    }
 		
 	// This is the form for submitting the completion codes and comments for an
 	// external HIT.
@@ -103,7 +111,7 @@ if ($isPreview) {
 
     //If access isn't granted, this worker has already done a survey in the group and will
     // be blocked from reaching the survey.
-    if ($accessController->checkAccess($workerId, $groupName, true, $surveyURL)) {        // ACCESS GRANTED
+    if ($accessController->checkAccess($workerId, $groupName, true, $surveyURLSave)) {        // ACCESS GRANTED
 	
 		$store = new tempStorage();
 		  

--- a/TurkGate/index.php
+++ b/TurkGate/index.php
@@ -237,16 +237,17 @@
 	}
 
 	function populateHITContent() {
-		var surveyURL = fix_http($('#externalSurveyURL').val())+"?";
+		var surveyURL = fix_http($('#externalSurveyURL').val());
 		var groupName = $('#groupName').val();
+        var passId = false;
 
 		if ($('#includeWID').is(":checked")) {
-			surveyURL += 'workerid=[[[Worker ID]]]';
+			passId = true;
 		}
 
     	switch ($("#HITType").val()) {
     		case "WebInterface":
-    			generateWebCode(surveyURL, groupName);
+    			generateWebCode(surveyURL, groupName, passId);
     			$("#WebHITContent").show();
     			break;
     		case "CLT":
@@ -313,13 +314,14 @@
 		});
 	}
 
-	function generateWebCode(surveyURL, groupName) {
+	function generateWebCode(surveyURL, groupName, passId) {
 		var copyright = "<!-- Copyright (c) 2012 Adam Darlow and Gideon Goldin. For more info, see http://gideongoldin.github.com/TurkGate/ -->\n"; 
 		
 		var htmlCode = <?php echo json_encode(file_get_contents('resources/WebHIT/webTemplate.html')); ?>;
 		htmlCode = htmlCode.replace('[[[Survey URL]]]', surveyURL);
 		htmlCode = htmlCode.replace('[[[Group Name]]]', groupName);
 		htmlCode = htmlCode.replace('[[[TurkGate URL]]]', "<?php echo constant('BASE_URL'); ?>");
+        htmlCode = htmlCode.replace('[[[Pass ID]]]', passId);
 		htmlCode = htmlCode.replace(/<!--[^>]*-->/, copyright);
 		
 		$('#generatedHTMLCode').val(htmlCode);

--- a/TurkGate/resources/WebHIT/webTemplate.html
+++ b/TurkGate/resources/WebHIT/webTemplate.html
@@ -18,6 +18,7 @@ limitations under the License.
   var surveyURL = "[[[Survey URL]]]";
   var group = "[[[Group Name]]]";
   var turkGateURL = "[[[TurkGate URL]]]";
+  var passId = [[[Pass ID]]];
 
 
   // dynamically creates the text that warns workers about the policy of access
@@ -80,6 +81,7 @@ limitations under the License.
       phpArgs += "&workerId=" + urlVars["workerId"];
       phpArgs += "&survey=" + encodeURIComponent(surveyURL);
       phpArgs += "&assignmentId=" + urlVars["assignmentId"];
+      phpArgs += "&passId=" + passId;
       return turkGateURL + '/gateway.php' + phpArgs;
     }  
   }
@@ -92,8 +94,6 @@ limitations under the License.
   	  	  
     var preview = (urlVars["assignmentId"] == undefined 
         || urlVars["assignmentId"] == "ASSIGNMENT_ID_NOT_AVAILABLE");
-
-    var passWid = (urlVars["workerId"] != undefined);
 
     surveyURL = surveyURL.replace('[[[Worker ID]]]', urlVars["workerId"]);
             
@@ -111,7 +111,7 @@ limitations under the License.
     	document.getElementById("acceptedText").style.display = "block";
     }
     
-    document.getElementById("groupText").innerHTML = createGroupText(preview, group, link, passWid);
+    document.getElementById("groupText").innerHTML = createGroupText(preview, group, link, passId);
   }
 </script>
 


### PR DESCRIPTION
Previously, the worker ID was passed to gateway.php twice: once as part of the survey URL and again as a separate parameter. I have simplified this by passing along a "passId" parameter through the URL instead, which tells gateway.php whether to pass along the worker ID or not.
